### PR TITLE
feat(settings): Added Occlusion Queries Settings for tested titles

### DIFF
--- a/settings/415608AF.toml
+++ b/settings/415608AF.toml
@@ -1,0 +1,5 @@
+# Title Name: Goldeneye: 007 Reloaded
+# Title ID: 415608AF
+
+[GPU]
+occlusion_query="strict" # Fixes unoccluded lens flares

--- a/settings/415608AF.toml
+++ b/settings/415608AF.toml
@@ -2,4 +2,4 @@
 # Title ID: 415608AF
 
 [GPU]
-occlusion_query="strict" # Fixes unoccluded lens flares
+occlusion_query="fast-alt" # Fixes unoccluded lens flares

--- a/settings/415608AF.toml
+++ b/settings/415608AF.toml
@@ -2,4 +2,4 @@
 # Title ID: 415608AF
 
 [GPU]
-occlusion_query="fast-alt" # Fixes unoccluded lens flares
+occlusion_query = "fast-alt" # Fixes unoccluded lens flares

--- a/settings/415688D0.toml
+++ b/settings/415688D0.toml
@@ -1,0 +1,5 @@
+# Title Name: GoldenEye 007 - Reloaded
+# Title ID: 415688D0
+
+[GPU]
+occlusion_query = "strict" # Fixes unoccluded lens flares

--- a/settings/415688D0.toml
+++ b/settings/415688D0.toml
@@ -2,4 +2,4 @@
 # Title ID: 415688D0
 
 [GPU]
-occlusion_query = "strict" # Fixes unoccluded lens flares
+occlusion_query = "fast-alt" # Fixes unoccluded lens flares

--- a/settings/425307E3.toml
+++ b/settings/425307E3.toml
@@ -2,4 +2,4 @@
 # Title ID: 425307E3
 
 [GPU]
-occlusion_query="fake" # Fixes popping geometry that happens on "fast" default
+occlusion_query = "fake" # Fixes popping geometry that happens on "fast" default

--- a/settings/425307E3.toml
+++ b/settings/425307E3.toml
@@ -1,0 +1,5 @@
+# Title Name: Dishonored
+# Title ID: 425307E3
+
+[GPU]
+occlusion_query="fake" # Fixes popping geometry that happens on "fast" default

--- a/settings/42560816.toml
+++ b/settings/42560816.toml
@@ -3,4 +3,4 @@
 
 [GPU]
 occlusion_query="fake" # Fixes flickering and performance issues
-query_occlusion_querybatch_range = 8 # Fixes flickering and performance issues
+occlusion_query_querybatch_range = 8 # Fixes flickering and performance issues

--- a/settings/42560816.toml
+++ b/settings/42560816.toml
@@ -1,0 +1,6 @@
+# Title Name: Disney Epic Mickey 2: The Power of Two
+# Title ID: 42560816
+
+[GPU]
+occlusion_query="fake" # Fixes flickering and performance issues
+query_occlusion_querybatch_range = 8 # Fixes flickering and performance issues

--- a/settings/42560816.toml
+++ b/settings/42560816.toml
@@ -2,5 +2,5 @@
 # Title ID: 42560816
 
 [GPU]
-occlusion_query="fake" # Fixes flickering and performance issues
+occlusion_query = "fake" # Fixes flickering and performance issues
 occlusion_query_querybatch_range = 8 # Fixes flickering and performance issues

--- a/settings/434D0839.toml
+++ b/settings/434D0839.toml
@@ -1,0 +1,5 @@
+# Title Name: Bodycount
+# Title ID: 434D0839
+
+[GPU]
+occlusion_query_fake_lower_threshold = 1 # Fixes the broken lens flare

--- a/settings/4541080F.toml
+++ b/settings/4541080F.toml
@@ -2,4 +2,5 @@
 # Title ID: 4541080F
 
 [GPU]
+occlusion_query_fake_lower_threshold = -1 # Fixes bleeding lights from the wall
 readback_resolve = "fast" # Fixes broken text at the slight cost of performance

--- a/settings/45410830.toml
+++ b/settings/45410830.toml
@@ -3,4 +3,4 @@
 
 [GPU]
 gamma_render_target_as_unorm16=false # Fixes broken gamma
-occlusion_query_sample_count_saturation=0.7 # Fixes excessive brightness
+occlusion_query_saturation=0.7 # Fixes excessive brightness

--- a/settings/45410830.toml
+++ b/settings/45410830.toml
@@ -2,5 +2,5 @@
 # Title ID: 45410830
 
 [GPU]
-gamma_render_target_as_unorm16=false # Fixes broken gamma
-occlusion_query_saturation=0.7 # Fixes excessive brightness
+gamma_render_target_as_unorm16 = false # Fixes broken gamma
+occlusion_query_saturation = 0.7 # Fixes excessive brightness

--- a/settings/45410830.toml
+++ b/settings/45410830.toml
@@ -1,0 +1,6 @@
+# Title Name: Left 4 Dead
+# Title ID: 45410830
+
+[GPU]
+gamma_render_target_as_unorm16=false # Fixes broken gamma
+occlusion_query_sample_count_saturation=0.7 # Fixes excessive brightness

--- a/settings/45410850.toml
+++ b/settings/45410850.toml
@@ -1,0 +1,5 @@
+# Title Name: Mirror's Edge
+# Title ID: 45410850
+
+[GPU]
+occlusion_query="strict" # Fixes unoccluded lens flares

--- a/settings/45410850.toml
+++ b/settings/45410850.toml
@@ -2,4 +2,4 @@
 # Title ID: 45410850
 
 [GPU]
-occlusion_query="strict" # Fixes unoccluded lens flares
+occlusion_query = "strict" # Fixes unoccluded lens flares

--- a/settings/454108CE.toml
+++ b/settings/454108CE.toml
@@ -3,4 +3,4 @@
 
 [GPU]
 occlusion_query="strict" # Fixes unoccluded lens flares
-occlusion_query_sample_count_saturation = 0.85 # Fixes unoccluded lens flares
+occlusion_query_saturation = 0.85 # Fixes unoccluded lens flares

--- a/settings/454108CE.toml
+++ b/settings/454108CE.toml
@@ -1,0 +1,6 @@
+# Title Name: Mass Effect 2
+# Title ID: 454108CE
+
+[GPU]
+occlusion_query="strict" # Fixes unoccluded lens flares
+occlusion_query_sample_count_saturation = 0.85 # Fixes unoccluded lens flares

--- a/settings/454108CE.toml
+++ b/settings/454108CE.toml
@@ -2,5 +2,5 @@
 # Title ID: 454108CE
 
 [GPU]
-occlusion_query="strict" # Fixes unoccluded lens flares
+occlusion_query = "strict" # Fixes unoccluded lens flares
 occlusion_query_saturation = 0.85 # Fixes unoccluded lens flares

--- a/settings/454108D4.toml
+++ b/settings/454108D4.toml
@@ -2,4 +2,4 @@
 # Title ID: 454108D4
 
 [GPU]
-occlusion_query_saturation=0.7 # Fixes excessive brightness
+occlusion_query_saturation = 0.7 # Fixes excessive brightness

--- a/settings/454108D4.toml
+++ b/settings/454108D4.toml
@@ -1,0 +1,6 @@
+# Title Name: Left 4 Dead 2
+# Title ID: 454108D4
+
+[GPU]
+gamma_render_target_as_unorm16=false # Fixes broken gamma
+occlusion_query_sample_count_saturation=0.7 # Fixes excessive brightness

--- a/settings/454108D4.toml
+++ b/settings/454108D4.toml
@@ -3,4 +3,4 @@
 
 [GPU]
 gamma_render_target_as_unorm16=false # Fixes broken gamma
-occlusion_query_sample_count_saturation=0.7 # Fixes excessive brightness
+occlusion_query_saturation=0.7 # Fixes excessive brightness

--- a/settings/454108D4.toml
+++ b/settings/454108D4.toml
@@ -2,5 +2,4 @@
 # Title ID: 454108D4
 
 [GPU]
-gamma_render_target_as_unorm16=false # Fixes broken gamma
 occlusion_query_saturation=0.7 # Fixes excessive brightness

--- a/settings/45410912.toml
+++ b/settings/45410912.toml
@@ -1,0 +1,7 @@
+# Title Name: Portal 2
+# Title ID: 45410912
+
+[GPU]
+readback_resolve = "fast" # Fixes the text not rendering
+gamma_render_target_as_unorm16=false # Gamma correction for Source engine games
+occlusion_query_sample_count_saturation=0.7 # Fixes excessive brightness

--- a/settings/45410912.toml
+++ b/settings/45410912.toml
@@ -3,5 +3,5 @@
 
 [GPU]
 readback_resolve = "fast" # Fixes the text not rendering
-gamma_render_target_as_unorm16=false # Gamma correction for Source engine games
-occlusion_query_saturation=0.7 # Fixes excessive brightness
+gamma_render_target_as_unorm16 = false # Gamma correction for Source engine games
+occlusion_query_saturation = 0.7 # Fixes excessive brightness

--- a/settings/45410912.toml
+++ b/settings/45410912.toml
@@ -4,4 +4,4 @@
 [GPU]
 readback_resolve = "fast" # Fixes the text not rendering
 gamma_render_target_as_unorm16=false # Gamma correction for Source engine games
-occlusion_query_sample_count_saturation=0.7 # Fixes excessive brightness
+occlusion_query_saturation=0.7 # Fixes excessive brightness

--- a/settings/4541095D.toml
+++ b/settings/4541095D.toml
@@ -1,0 +1,5 @@
+# Title Name: Mass Effect 3
+# Title ID: 4541095D
+
+[GPU]
+occlusion_query="strict" # Fixes unoccluded lens flares

--- a/settings/4541095D.toml
+++ b/settings/4541095D.toml
@@ -2,4 +2,4 @@
 # Title ID: 4541095D
 
 [GPU]
-occlusion_query="strict" # Fixes unoccluded lens flares
+occlusion_query = "strict" # Fixes unoccluded lens flares

--- a/settings/4541096E.toml
+++ b/settings/4541096E.toml
@@ -5,4 +5,4 @@
 occlusion_query_fake_lower_threshold = 0 # Fixes lens flares
 occlusion_query_fake_upper_threshold = 0 # Fixes lens flares
 readback_resolve = "full" # Stops the game from hanging during the intro
-occlusion_query="fake" # Fixes hanging
+occlusion_query = "fake" # Fixes hanging

--- a/settings/4541096E.toml
+++ b/settings/4541096E.toml
@@ -3,3 +3,4 @@
 
 [GPU]
 readback_resolve = "full" # Stops the game from hanging during the intro
+occlusion_query="fake" # Fixes hanging

--- a/settings/4541096E.toml
+++ b/settings/4541096E.toml
@@ -2,5 +2,7 @@
 # Title ID: 4541096E
 
 [GPU]
+occlusion_query_fake_lower_threshold = 0 # Fixes lens flares
+occlusion_query_fake_upper_threshold = 0 # Fixes lens flares
 readback_resolve = "full" # Stops the game from hanging during the intro
 occlusion_query="fake" # Fixes hanging

--- a/settings/475007D4.toml
+++ b/settings/475007D4.toml
@@ -2,4 +2,4 @@
 # Title ID: 475007D4
 
 [GPU]
-occlusion_query="strict" # Fixes unoccluded lens flares
+occlusion_query = "strict" # Fixes unoccluded lens flares

--- a/settings/475007D4.toml
+++ b/settings/475007D4.toml
@@ -1,0 +1,5 @@
+# Title Name: Section 8
+# Title ID: 475007D4
+
+[GPU]
+occlusion_query="strict" # Fixes unoccluded lens flares

--- a/settings/4B4D07F5.toml
+++ b/settings/4B4D07F5.toml
@@ -1,0 +1,5 @@
+# Title Name: Metro Last Light
+# Title ID: 4B4D07F5
+
+[GPU]
+gpu = "vulkan" # Fixes unoccluded lens flares (along with occlusion_query="fast" (default)

--- a/settings/4D5307D2.toml
+++ b/settings/4D5307D2.toml
@@ -2,4 +2,4 @@
 # Title ID: 4D5307D2
 
 [GPU]
-occlusion_query="strict" # Fixes unoccluded lens flares
+occlusion_query = "strict" # Fixes unoccluded lens flares

--- a/settings/4D5307D2.toml
+++ b/settings/4D5307D2.toml
@@ -1,0 +1,5 @@
+# Title Name: Kameo: Elements of Power
+# Title ID: 4D5307D2
+
+[GPU]
+occlusion_query="strict" # Fixes unoccluded lens flares

--- a/settings/4D5307DE.toml
+++ b/settings/4D5307DE.toml
@@ -2,4 +2,4 @@
 # Title ID: 4D5307DE
 
 [GPU]
-occlusion_query="fast-alt" # Fixes unoccluded lens flares
+occlusion_query = "fast-alt" # Fixes unoccluded lens flares

--- a/settings/4D5307DE.toml
+++ b/settings/4D5307DE.toml
@@ -2,4 +2,4 @@
 # Title ID: 4D5307DE
 
 [GPU]
-occlusion_query="strict" # Fixes unoccluded lens flares
+occlusion_query="fast-alt" # Fixes unoccluded lens flares

--- a/settings/4D5307DE.toml
+++ b/settings/4D5307DE.toml
@@ -1,0 +1,5 @@
+# Title Name: Too Human
+# Title ID: 4D5307DE
+
+[GPU]
+occlusion_query="strict" # Fixes unoccluded lens flares

--- a/settings/4D5307E8.toml
+++ b/settings/4D5307E8.toml
@@ -2,5 +2,5 @@
 # Title ID: 4D5307E8
 
 [GPU]
-occlusion_query="strict" # Fixes unoccluded lens flares
+occlusion_query = "strict" # Fixes unoccluded lens flares
 occlusion_query_saturation = 0.75 # Fixes excessively bright flares

--- a/settings/4D5307E8.toml
+++ b/settings/4D5307E8.toml
@@ -3,4 +3,4 @@
 
 [GPU]
 occlusion_query="strict" # Fixes unoccluded lens flares
-occlusion_query_sample_count_saturation = 0.75 # Fixes excessively bright flares
+occlusion_query_saturation = 0.75 # Fixes excessively bright flares

--- a/settings/4D5307E8.toml
+++ b/settings/4D5307E8.toml
@@ -1,0 +1,6 @@
+# Title Name: Mass Effect
+# Title ID: 4D5307E8
+
+[GPU]
+occlusion_query="strict" # Fixes unoccluded lens flares
+occlusion_query_sample_count_saturation = 0.75

--- a/settings/4D5307E8.toml
+++ b/settings/4D5307E8.toml
@@ -3,4 +3,4 @@
 
 [GPU]
 occlusion_query="strict" # Fixes unoccluded lens flares
-occlusion_query_sample_count_saturation = 0.75
+occlusion_query_sample_count_saturation = 0.75 # Fixes excessively bright flares

--- a/settings/4D53082D.toml
+++ b/settings/4D53082D.toml
@@ -3,6 +3,7 @@
 
 [GPU]
 vsync = false # Unlocks framerate (Combined with framerate limit set to 0)
+occlusion_query = "strict" # Fixes unoccluded lens flares
 
 [Kernel]
 cl = "-NoStartupMovies" # Skips intro

--- a/settings/4D5308AB.toml
+++ b/settings/4D5308AB.toml
@@ -3,6 +3,7 @@
 
 [GPU]
 vsync = false # Unlocks framerate (Combined with framerate limit set to 0)
+occlusion_query = "strict" # Fixes unoccluded lens flares
 
 [Kernel]
 cl = "-NoStartupMovies" # Skips intro

--- a/settings/4D5309B1.toml
+++ b/settings/4D5309B1.toml
@@ -4,4 +4,4 @@
 [GPU]
 clear_memory_page_state = true # Fixes warped graphics in game
 occlusion_query_querybatch_range = 256 # Fixes textures not loading
-occlusion_query="fake" # Fixes textures not loading
+occlusion_query = "fake" # Fixes textures not loading

--- a/settings/4D5309B1.toml
+++ b/settings/4D5309B1.toml
@@ -3,5 +3,5 @@
 
 [GPU]
 clear_memory_page_state = true # Fixes warped graphics in game
-query_occlusion_querybatch_range = 256 
-occlusion_query="fake"
+query_occlusion_querybatch_range = 256 # Fixes textures not loading
+occlusion_query="fake" # Fixes textures not loading

--- a/settings/4D5309B1.toml
+++ b/settings/4D5309B1.toml
@@ -3,5 +3,5 @@
 
 [GPU]
 clear_memory_page_state = true # Fixes warped graphics in game
-query_occlusion_querybatch_range = 256 # Fixes textures not loading
+occlusion_query_querybatch_range = 256 # Fixes textures not loading
 occlusion_query="fake" # Fixes textures not loading

--- a/settings/4D5309B1.toml
+++ b/settings/4D5309B1.toml
@@ -3,3 +3,5 @@
 
 [GPU]
 clear_memory_page_state = true # Fixes warped graphics in game
+query_occlusion_querybatch_range = 256 
+occlusion_query="fake"

--- a/settings/4D530A26.toml
+++ b/settings/4D530A26.toml
@@ -3,3 +3,4 @@
 
 [GPU]
 vsync = false # Unlocks framerate (Combined with framerate limit set to 0)
+occlusion_query = "strict" # Fixes unoccluded lens flares

--- a/settings/4E4D085B.toml
+++ b/settings/4E4D085B.toml
@@ -1,0 +1,5 @@
+# Title Name: Star Trek
+# Title ID: 4E4D085B
+
+[GPU]
+occlusion_query="strict" # Fixes unoccluded lens flares

--- a/settings/4E4D085B.toml
+++ b/settings/4E4D085B.toml
@@ -2,4 +2,4 @@
 # Title ID: 4E4D085B
 
 [GPU]
-occlusion_query="strict" # Fixes unoccluded lens flares
+occlusion_query = "strict" # Fixes unoccluded lens flares

--- a/settings/545107FC.toml
+++ b/settings/545107FC.toml
@@ -2,7 +2,7 @@
 # Title ID: 545107FC
 
 [GPU]
-occlusion_query="fast-alt"
+occlusion_query="fast-alt" # Fixes unoccluded lens flares
 
 [Memory]
 protect_zero = false # Fixes freezing issues

--- a/settings/545107FC.toml
+++ b/settings/545107FC.toml
@@ -2,7 +2,7 @@
 # Title ID: 545107FC
 
 [GPU]
-occlusion_query="fast-alt" # Fixes unoccluded lens flares
+occlusion_query = "fast-alt" # Fixes unoccluded lens flares
 
 [Memory]
 protect_zero = false # Fixes freezing issues

--- a/settings/545107FC.toml
+++ b/settings/545107FC.toml
@@ -1,5 +1,8 @@
 # Title Name: Saints Row 2
 # Title ID: 545107FC
 
+[GPU]
+occlusion_query="fast-alt"
+
 [Memory]
 protect_zero = false # Fixes freezing issues

--- a/settings/5451082C.toml
+++ b/settings/5451082C.toml
@@ -2,4 +2,4 @@
 # Title ID: 5451082C
 
 [GPU]
-occlusion_query="fake" # Fixes hanging
+occlusion_query = "fake" # Fixes hanging

--- a/settings/5451082C.toml
+++ b/settings/5451082C.toml
@@ -1,0 +1,5 @@
+# Title Name: Warhammer 40K Space Marine
+# Title ID: 5451082C
+
+[GPU]
+occlusion_query="fake" # Fixes hanging

--- a/settings/54510842.toml
+++ b/settings/54510842.toml
@@ -1,0 +1,5 @@
+# Title Name: Metro 2033
+# Title ID: 54510842
+
+[GPU]
+occlusion_query="strict" # Fixes unoccluded lens flares

--- a/settings/54510842.toml
+++ b/settings/54510842.toml
@@ -2,4 +2,4 @@
 # Title ID: 54510842
 
 [GPU]
-occlusion_query="strict" # Fixes unoccluded lens flares
+occlusion_query = "strict" # Fixes unoccluded lens flares

--- a/settings/54510846.toml
+++ b/settings/54510846.toml
@@ -2,4 +2,4 @@
 # Title ID: 54510846
 
 [GPU]
-occlusion_query="strict" # Fixes unoccluded lens flares
+occlusion_query = "strict" # Fixes unoccluded lens flares

--- a/settings/54510846.toml
+++ b/settings/54510846.toml
@@ -1,0 +1,5 @@
+# Title Name: Homefront
+# Title ID: 54510846
+
+[GPU]
+occlusion_query="strict" # Fixes unoccluded lens flares

--- a/settings/5451087B.toml
+++ b/settings/5451087B.toml
@@ -2,7 +2,6 @@
 # Title ID: 5451087B
 
 [GPU]
-framerate_limit = 0 # Unlocks framerate (Combined with disabled vertical sync)
 occlusion_query_fake_lower_threshold = -1 # Fixes brightness
 readback_resolve = "full" # Fixes the textures at the cost of performance
 vsync = false # Unlocks framerate (Combined with framerate limit set to 0)

--- a/settings/5451087B.toml
+++ b/settings/5451087B.toml
@@ -2,5 +2,7 @@
 # Title ID: 5451087B
 
 [GPU]
+framerate_limit = 0 # Unlocks framerate (Combined with disabled vertical sync)
+occlusion_query_fake_lower_threshold = -1 # Fixes brightness
 readback_resolve = "full" # Fixes the textures at the cost of performance
 vsync = false # Unlocks framerate (Combined with framerate limit set to 0)

--- a/settings/5454085D.toml
+++ b/settings/5454085D.toml
@@ -2,4 +2,4 @@
 # Title ID: 5454085D
 
 [GPU]
-occlusion_query="strict" # Fixes unoccluded lens flares
+occlusion_query = "strict" # Fixes unoccluded lens flares

--- a/settings/5454085D.toml
+++ b/settings/5454085D.toml
@@ -1,0 +1,5 @@
+# Title Name: Bioshock Infinite
+# Title ID: 5454085D
+
+[GPU]
+occlusion_query="strict" # Fixes unoccluded lens flares

--- a/settings/565707D0.toml
+++ b/settings/565707D0.toml
@@ -1,0 +1,5 @@
+# Title Name: Lollipop Chainsaw
+# Title ID: 565707D0
+
+[GPU]
+occlusion_query="strict" # Fixes unoccluded lens flares

--- a/settings/565707D0.toml
+++ b/settings/565707D0.toml
@@ -2,4 +2,4 @@
 # Title ID: 565707D0
 
 [GPU]
-occlusion_query="strict" # Fixes unoccluded lens flares
+occlusion_query = "strict" # Fixes unoccluded lens flares

--- a/settings/57520802.toml
+++ b/settings/57520802.toml
@@ -2,4 +2,4 @@
 # Title ID: 57520802
 
 [GPU]
-occlusion_query="strict" # Fixes unoccluded lens flares
+occlusion_query = "strict" # Fixes unoccluded lens flares

--- a/settings/57520802.toml
+++ b/settings/57520802.toml
@@ -1,0 +1,5 @@
+# Title Name: Batman: Arkham City
+# Title ID: 57520802
+
+[GPU]
+occlusion_query="strict" # Fixes unoccluded lens flares

--- a/settings/58410955.toml
+++ b/settings/58410955.toml
@@ -1,6 +1,0 @@
-# Title Name: Banjo-Tooie
-# Title ID: 58410955
-
-
-[Video]
-internal_display_resolution = 16 # Displays the game at 1080p

--- a/settings/58410955.toml
+++ b/settings/58410955.toml
@@ -1,0 +1,6 @@
+# Title Name: Banjo-Tooie
+# Title ID: 58410955
+
+
+[Video]
+internal_display_resolution = 16 # Displays the game at 1080p

--- a/settings/58410960.toml
+++ b/settings/58410960.toml
@@ -7,7 +7,8 @@ break_on_unimplemented_instructions = false # Stops the game from crashing
 [GPU]
 clear_memory_page_state = true # Fixes warped graphics in game
 readback_resolve = "fast" # Fixes the garbled text
-render_target_path_d3d12 = "rov" # Fixes the lighting
+gamma_render_target_as_unorm16=false # Fixed broken gamma on Source engine games
+occlusion_query_sample_count_saturation=0.7 # Fixes excessive lighting
 
 [Kernel]
 cl = "-dvd -game portal +fps_max 0" # Boots the game and unlocks framerate

--- a/settings/58410960.toml
+++ b/settings/58410960.toml
@@ -7,7 +7,6 @@ break_on_unimplemented_instructions = false # Stops the game from crashing
 [GPU]
 clear_memory_page_state = true # Fixes warped graphics in game
 readback_resolve = "fast" # Fixes the garbled text
-gamma_render_target_as_unorm16=false # Fixed broken gamma on Source engine games
 occlusion_query_saturation=0.7 # Fixes excessive lighting
 
 [Kernel]

--- a/settings/58410960.toml
+++ b/settings/58410960.toml
@@ -7,7 +7,7 @@ break_on_unimplemented_instructions = false # Stops the game from crashing
 [GPU]
 clear_memory_page_state = true # Fixes warped graphics in game
 readback_resolve = "fast" # Fixes the garbled text
-occlusion_query_saturation=0.7 # Fixes excessive lighting
+occlusion_query_saturation = 0.7 # Fixes excessive lighting
 
 [Kernel]
 cl = "-dvd -game portal +fps_max 0" # Boots the game and unlocks framerate

--- a/settings/58410960.toml
+++ b/settings/58410960.toml
@@ -8,7 +8,7 @@ break_on_unimplemented_instructions = false # Stops the game from crashing
 clear_memory_page_state = true # Fixes warped graphics in game
 readback_resolve = "fast" # Fixes the garbled text
 gamma_render_target_as_unorm16=false # Fixed broken gamma on Source engine games
-occlusion_query_sample_count_saturation=0.7 # Fixes excessive lighting
+occlusion_query_saturation=0.7 # Fixes excessive lighting
 
 [Kernel]
 cl = "-dvd -game portal +fps_max 0" # Boots the game and unlocks framerate

--- a/settings/584109C2.toml
+++ b/settings/584109C2.toml
@@ -1,0 +1,6 @@
+# Title Name: Perfect Dark
+# Title ID: 584109C2
+
+
+[Video]
+internal_display_resolution = 16 # Renders the game at 1080p

--- a/settings/584109C2.toml
+++ b/settings/584109C2.toml
@@ -1,6 +1,0 @@
-# Title Name: Perfect Dark
-# Title ID: 584109C2
-
-
-[Video]
-internal_display_resolution = 16 # Renders the game at 1080p

--- a/settings/5841125A.toml
+++ b/settings/5841125A.toml
@@ -2,5 +2,5 @@
 # Title ID: 5841125A
 
 [GPU]
-occlusion_query="strict" # Fixes unoccluded lens flares
-occlusion_query_saturation=0.7 # Fixes unoccluded lens flares
+occlusion_query = "strict" # Fixes unoccluded lens flares
+occlusion_query_saturation = 0.7 # Fixes unoccluded lens flares

--- a/settings/5841125A.toml
+++ b/settings/5841125A.toml
@@ -3,4 +3,4 @@
 
 [GPU]
 occlusion_query="strict" # Fixes unoccluded lens flares
-occlusion_query_sample_count_saturation=0.7 # Fixes unoccluded lens flares
+occlusion_query_saturation=0.7 # Fixes unoccluded lens flares

--- a/settings/5841125A.toml
+++ b/settings/5841125A.toml
@@ -1,0 +1,6 @@
+# Title Name: Counter Strike: GO
+# Title ID: 5841125A
+
+[GPU]
+occlusion_query="strict" # Fixes unoccluded lens flares
+occlusion_query_sample_count_saturation=0.7 # Fixes unoccluded lens flares

--- a/settings/584113CF.toml
+++ b/settings/584113CF.toml
@@ -2,5 +2,5 @@
 # Title ID: 584113CF
 
 [GPU]
-occlusion_query="fake" # Fixes unoccluded lens flares
+occlusion_query = "fake" # Fixes unoccluded lens flares
 occlusion_query_querybatch_range = 256 # Fixes unoccluded lens flares

--- a/settings/584113CF.toml
+++ b/settings/584113CF.toml
@@ -1,0 +1,6 @@
+# Title Name: God Mode
+# Title ID: 584113CF
+
+[GPU]
+occlusion_query="fake" # Fixes unoccluded lens flares
+query_occlusion_querybatch_range = 256 # Fixes unoccluded lens flares

--- a/settings/584113CF.toml
+++ b/settings/584113CF.toml
@@ -3,4 +3,4 @@
 
 [GPU]
 occlusion_query="fake" # Fixes unoccluded lens flares
-query_occlusion_querybatch_range = 256 # Fixes unoccluded lens flares
+occlusion_query_querybatch_range = 256 # Fixes unoccluded lens flares

--- a/settings/58411411.toml
+++ b/settings/58411411.toml
@@ -3,4 +3,4 @@
 
 [GPU]
 clear_memory_page_state = true # Fixes the warped graphics in game
-occlusion_query="strict" # Fixes unoccluded lens flares
+occlusion_query = "strict" # Fixes unoccluded lens flares

--- a/settings/58411411.toml
+++ b/settings/58411411.toml
@@ -3,3 +3,4 @@
 
 [GPU]
 clear_memory_page_state = true # Fixes the warped graphics in game
+occlusion_query="strict" # Fixes unoccluded lens flares


### PR DESCRIPTION
Based on testing done during ZPD OQ implementation, the following setting changes need to be applied to take advantage of ZPD, considering `occlusion_query="fast"` is the new default.

--> **Changes to existing settings**

- 4D530910, 4D53084D, 4D530919, 4D53085B, 545407EE
Removed query_occlusion_sample_lower_threshold = -1 now that it's no longer needed

- 58410960
Added occ sample count < 1

- 4D530A26, 4D5308AB, 4D53082D, 58411411
Added occlusion_query="strict"

- 415688D0, 545107FC
Added occlusion_query="fast-alt" and removed query_occlusion_sample_lower_threshold + query_occlusion_sample_upper_threshold

- 4D5309B1
Added query_occlusion_querybatch_range = 256, occlusion_query="fake"

--> **New entries**

- 5454085D, 57520802, 5841125A, 54510846, 4D5307D2, 565707D0, 4D5307E8, 454108CE, 4541095D, 54510842, 45410850, 475007D4
Games that need occlusion_query="strict" to fix unoccluded lens flares

- 415608AF, 4D5307DE
Games that need occlusion_query="fast-alt"

- 425307E3, 4541096E, 5451082C
Games that need occlusion_query="fake" to prevent hanging

- 42560816, 584113CF
Games that need "fake" and querybatch

- 45410830, 45410912
Games that need gamma unorm16 as false and occ sample count < 1

- 454108D4 
Games that need occ sample count < 1

- 4B4D07F5
Games that need vulkan to properly occlude lens flares