### PR TITLE
chore(settings): Additional Occlusion settings and other fixes

### DIFF
--- a/settings/434D0819.toml
+++ b/settings/434D0819.toml
@@ -2,8 +2,8 @@
 # Title ID: 434D0819
 
 [APU]
-xma_decoder = "old" #Fixes hang on certain events
-use_dedicated_xma_thread = false #Fixes hang on certain events
+xma_decoder = "old" # Fixes hang on certain events
+use_dedicated_xma_thread = false # Fixes hang on certain events
 
 [GPU]
-readback_resolve = "full" #Fixes brightness and water reflections
+readback_resolve = "full" # Fixes brightness and water reflections

--- a/settings/434D0819.toml
+++ b/settings/434D0819.toml
@@ -1,0 +1,9 @@
+# Title Name: DiRT 2
+# Title ID: 434D0819
+
+[APU]
+xma_decoder = "old" #Fixes hang on certain events
+use_dedicated_xma_thread = false #Fixes hang on certain events
+
+[GPU]
+readback_resolve = "full" #Fixes brightness and water reflections

--- a/settings/45410830.toml
+++ b/settings/45410830.toml
@@ -4,3 +4,4 @@
 [GPU]
 gamma_render_target_as_unorm16 = false # Fixes broken gamma
 occlusion_query_saturation = 0.7 # Fixes excessive brightness
+readback_resolve = "full" # Fixes garbled text

--- a/settings/494707EE.toml
+++ b/settings/494707EE.toml
@@ -1,0 +1,5 @@
+# Title Name: Assault on Dark Athena
+# Title ID: 494707EE
+
+[GPU]
+occlusion_query = "fast-alt" #Fixes autoexposure issue (brightness)

--- a/settings/494707EE.toml
+++ b/settings/494707EE.toml
@@ -2,4 +2,4 @@
 # Title ID: 494707EE
 
 [GPU]
-occlusion_query = "fast-alt" #Fixes autoexposure issue (brightness)
+occlusion_query = "fast-alt" # Fixes autoexposure issue (brightness)

--- a/settings/4D530877.toml
+++ b/settings/4D530877.toml
@@ -2,4 +2,4 @@
 # Title ID: 4D530877
 
 [GPU]
-readback_resolve = "full" #Fixes excessive brightness
+readback_resolve = "full" # Fixes excessive brightness

--- a/settings/4D530877.toml
+++ b/settings/4D530877.toml
@@ -1,8 +1,5 @@
 # Title Name: Halo 3 ODST
 # Title ID: 4D530877
 
-[Memory]
-protect_zero = false # Stops the crashing in the menu
-
-[Storage]
-mount_cache = false # Game will be stuck in a black screen if it's set to true
+[GPU]
+readback_resolve = "full" #Fixes excessive brightness

--- a/settings/534307E7.toml
+++ b/settings/534307E7.toml
@@ -1,0 +1,5 @@
+# Title Name: Just Cause 2
+# Title ID: 534307E7
+
+[GPU]
+gpu = "vulkan" #Fixes vehicle models not rendering

--- a/settings/534307E7.toml
+++ b/settings/534307E7.toml
@@ -2,4 +2,4 @@
 # Title ID: 534307E7
 
 [GPU]
-gpu = "vulkan" #Fixes vehicle models not rendering
+gpu = "vulkan" # Fixes vehicle models not rendering

--- a/settings/555307D4.toml
+++ b/settings/555307D4.toml
@@ -1,0 +1,5 @@
+# Title Name: Assassin's Creed
+# Title ID: 555307D4
+
+[GPU]
+occlusion_query = "strict" #Fixes flickering geometry and unoccluded lens flares

--- a/settings/555307D4.toml
+++ b/settings/555307D4.toml
@@ -2,4 +2,4 @@
 # Title ID: 555307D4
 
 [GPU]
-occlusion_query = "strict" #Fixes flickering geometry and unoccluded lens flares
+occlusion_query = "strict" # Fixes flickering geometry and unoccluded lens flares

--- a/settings/5553083B.toml
+++ b/settings/5553083B.toml
@@ -2,4 +2,4 @@
 # Title ID: 5553083B
 
 [GPU]
-occlusion_query = "strict" #Fixes flickering geometry and unoccluded lens flares
+occlusion_query = "strict" # Fixes flickering geometry and unoccluded lens flares

--- a/settings/5553083B.toml
+++ b/settings/5553083B.toml
@@ -1,0 +1,5 @@
+# Title Name: Assassin's Creed II
+# Title ID: 5553083B
+
+[GPU]
+occlusion_query = "strict" #Fixes flickering geometry and unoccluded lens flares

--- a/settings/58411202.toml
+++ b/settings/58411202.toml
@@ -1,0 +1,8 @@
+# Title Name: Sonic Adventure 2
+# Title ID: 58411202
+
+[GPU]
+gpu = "vulkan" # Fixes missing and corrupted textures
+
+[Content]
+license_mask = 1 # Unlocks full game

--- a/settings/58411202.toml
+++ b/settings/58411202.toml
@@ -1,8 +1,8 @@
 # Title Name: Sonic Adventure 2
 # Title ID: 58411202
 
-[GPU]
-gpu = "vulkan" # Fixes missing and corrupted textures
-
 [Content]
 license_mask = 1 # Unlocks full game
+
+[GPU]
+gpu = "vulkan" # Fixes missing and corrupted textures


### PR DESCRIPTION
## Summary

**Game(s):**

- `534307E7` — Just Cause 2
- `5553083B` — Assassin's Creed II
- `494707EE` — The Chronicles Of Riddick Assault On Dark Athena
- `555307D4` — Assassin's Creed
- `434D0819` — DiRT 2
- `45410830` — Left 4 Dead
- `4D530877` — Halo 3: ODST
- `58411202` — Sonic Adventure 2

**Type:** `New Addition` / `Improvement`

Additional settings for occlusion queries and other settings tested in my recent playthroughs.

---

## Changes

> Repeat this section for each game.

### `534307E7` — Just Cause 2

| Setting | Value   | Section | Purpose           |
| ------- | ------- | ------- | ----------------- |
| `gpu`   | `vulkan` | `[GPU]` | Fixes vehicle models not rendering |

### `5553083B` — Assassin's Creed II

| Setting | Value   | Section | Purpose           |
| ------- | ------- | ------- | ----------------- |
| `occlusion_query`   | `strict` | `[GPU]` | Fixes flickering geometry and unoccluded lens flares |

### `555307D4` — Assassin's Creed

| Setting | Value   | Section | Purpose           |
| ------- | ------- | ------- | ----------------- |
| `occlusion_query`   | `strict` | `[GPU]` | Fixes flickering geometry and unoccluded lens flares |

### `494707EE` — The Chronicles Of Riddick Assault On Dark Athena

| Setting | Value   | Section | Purpose           |
| ------- | ------- | ------- | ----------------- |
| `occlusion_query`   | `fast-alt` | `[GPU]` | Fixes autoexposure issue (brightness) |

### `434D0819` — Dirt 2

| Setting | Value   | Section | Purpose           |
| ------- | ------- | ------- | ----------------- |
| `xma_decoder`   | `old` | `[APU]` | Fixes hang on certain events |
| `use_dedicated_xma_thread`   | `false` | `[APU]` | Fixes hang on certain events |
| `readback_resolve`   | `full` | `[GPU]` | Fixes brightness and water reflections |

### `45410830` — Left 4 Dead

| Setting | Value   | Section | Purpose           |
| ------- | ------- | ------- | ----------------- |
| `readback_resolve`   | `full` | `[GPU]` | Fixes garbled text |

### `4D530877` — Halo 3 ODST

| Setting | Value   | Section | Purpose           |
| ------- | ------- | ------- | ----------------- |
| `readback_resolve`   | `full` | `[GPU]` | Fixes excessive brightness |

### `58411202` — Sonic Adventure 2

| Setting | Value   | Section | Purpose           |
| ------- | ------- | ------- | ----------------- |
| `gpu`   | `vulkan` | `[GPU]` | Fixes missing and corrupted textures |
| `license_mask`   | `1` | `[Content]` | Unlocks full game |

---

## Screenshots

> Repeat this section per game or per setting. Compare default vs. optimized settings. Attach images directly or paste image URLs.

Screenshots available in the compatibility reports:
- `534307E7` — [Just Cause 2](https://github.com/xenia-canary/game-compatibility/issues/989)
- `5553083B` — [Assassin's Creed II](https://github.com/xenia-canary/game-compatibility/issues/64)
- `494707EE` — [The Chronicles Of Riddick Assault On Dark Athena](https://github.com/xenia-canary/game-compatibility/issues/1046)
- `555307D4` — [Assassin's Creed](https://github.com/xenia-canary/game-compatibility/issues/962)
- `434D0819` — [DiRT 2](https://github.com/xenia-canary/game-compatibility/issues/326)
- `45410830` — [Left 4 Dead](https://github.com/xenia-canary/game-compatibility/issues/910)
- `4D530877` — [Halo 3: ODST](https://github.com/xenia-canary/game-compatibility/issues/215)
- `58411202` — [Sonic Adventure 2](https://github.com/xenia-canary/game-compatibility/issues/958)
