### PR TITLE
chore(settings): Add/Update game-specific settings for 9 games

### DIFF
--- a/settings/415607D4.toml
+++ b/settings/415607D4.toml
@@ -1,0 +1,5 @@
+# Title Name: American Wasteland
+# Title ID: 415607D4
+
+[GPU]
+clear_memory_page_state = true # Partially fixes the flickering FMVs but still happens.

--- a/settings/45410866.toml
+++ b/settings/45410866.toml
@@ -1,0 +1,5 @@
+# Title Name: The Godfather II
+# Title ID: 45410866
+
+[GPU]
+occlusion_query = "fake" # Avoids flickering geometry.

--- a/settings/5345082A.toml
+++ b/settings/5345082A.toml
@@ -1,0 +1,5 @@
+# Title Name: Aliens vs Predator
+# Title ID: 5345082A
+
+[GPU]
+render_target_path_d3d12 = "rov" # Renders graphics.

--- a/settings/544307D5.toml
+++ b/settings/544307D5.toml
@@ -1,8 +1,5 @@
 # Title Name: Ninja Gaiden 2
 # Title ID: 544307D5
 
-[APU]
-apu_max_queued_frames = 4 # Stops the audio delay
-
 [GPU]
 clear_memory_page_state = true # Fixes warped graphics in game

--- a/settings/5451080D.toml
+++ b/settings/5451080D.toml
@@ -1,0 +1,5 @@
+# Title Name: Red Faction Guerrilla
+# Title ID: 5451080D
+
+[GPU]
+vsync = false # Unlocks FPS (Combined with Framerate Limit set to 0).

--- a/settings/555307EA.toml
+++ b/settings/555307EA.toml
@@ -1,0 +1,6 @@
+# Title Name: Brothers in Arms - Hell's Highway
+# Title ID: 555307EA
+
+[GPU]
+render_target_path_d3d12 = "rov" # Fixes the flickering shadows at the cost of performance.
+vsync = false # Unlocks FPS (Combined with Framerate Limit set to 0).

--- a/settings/555308AE.toml
+++ b/settings/555308AE.toml
@@ -1,0 +1,9 @@
+# Title Name: Assassins Creed III
+# Title ID: 555308AE
+
+[GPU]
+occlusion_query = "strict" # Fixes lens flares and prevents geometry flickering.
+vsync = false # Unlocks FPS (Combined with Framerate Limit set to 0).
+
+[General]
+launch_module = "scimitar_final.xex" # launches the singleplayer.

--- a/settings/555308C2.toml
+++ b/settings/555308C2.toml
@@ -1,0 +1,10 @@
+# Title Name: Assassins Creed IV Black Flag
+# Title ID: 555308C2
+
+[GPU]
+framerate_limit = 120 # Caps the FPS to 60.
+occlusion_query = "strict" # Prevents unoccluded lens flares.
+readback_resolve = "full" # Fixes eye textures.
+
+[General]
+launch_module = "scimitar_final.xex" # launches the singleplayer.

--- a/settings/58410B3A.toml
+++ b/settings/58410B3A.toml
@@ -1,0 +1,6 @@
+# Title Name: I Am Alive
+# Title ID: 58410B3A
+
+[GPU]
+clear_memory_page_state = true # Fixes the flickering intro videos.
+readback_resolve = "fast" # Fixes the brightness.


### PR DESCRIPTION
**Game(s):**

- `415607D4` — Tony Hawk's American Wasteland
- `45410866` — The Godfather II
- `5345082A` — Aliens vs Predator
- `5451080D` — Red Faction Guerrilla
- `555307EA` — Brothers in Arms - Hell's Highway
- `555308AE` — Assassin's Creed III
- `555308C2` — Assassin's Creed IV Black Flag
- `58410B3A` — I Am Alive
- `544307D5` — Ninja Gaiden 2

**Type:** `New Addition` / `Refactor`

Adds optimized game-specific settings for 8 titles to fix various graphical issues including flickering geometry, missing rendering, brightness problems, and unlocked FPS. Also removes deprecated `apu_max_queued_frames` setting from Ninja Gaiden 2.

---

## Changes

### `415607D4` — Tony Hawk's American Wasteland

| Setting                 | Value  | Section | Purpose                                      |
| ----------------------- | ------ | ------- | -------------------------------------------- |
| `clear_memory_page_state` | `true` | `[GPU]` | Partially fixes the flickering FMVs          |

**Problems Fixed:**

- Flickering FMVs during gameplay

### `45410866` — The Godfather II

| Setting           | Value    | Section | Purpose                     |
| ----------------- | -------- | ------- | --------------------------- |
| `occlusion_query` | `"fake"` | `[GPU]` | Avoids flickering geometry  |

**Problems Fixed:**

- Geometry flickering throughout the game

### `5345082A` — Aliens vs Predator

| Setting                  | Value  | Section | Purpose        |
| ------------------------ | ------ | ------- | -------------- |
| `render_target_path_d3d12` | `"rov"` | `[GPU]` | Renders graphics |

**Problems Fixed:**

- Missing or broken graphics rendering

### `5451080D` — Red Faction Guerrilla

| Setting | Value  | Section | Purpose                                    |
| ------- | ------ | ------- | ------------------------------------------ |
| `vsync` | `false` | `[GPU]` | Unlocks FPS (Combined with Framerate Limit set to 0) |

**Problems Fixed:**

- FPS capped to monitor refresh rate

### `555307EA` — Brothers in Arms - Hell's Highway

| Setting                  | Value  | Section | Purpose                                      |
| ------------------------ | ------ | ------- | -------------------------------------------- |
| `render_target_path_d3d12` | `"rov"` | `[GPU]` | Fixes the flickering shadows at the cost of performance |
| `vsync`                  | `false` | `[GPU]` | Unlocks FPS (Combined with Framerate Limit set to 0) |

**Problems Fixed:**

- Flickering shadows
- FPS capped to monitor refresh rate

### `555308AE` — Assassin's Creed III

| Setting           | Value      | Section     | Purpose                                      |
| ----------------- | ---------- | ----------- | -------------------------------------------- |
| `occlusion_query` | `"strict"` | `[GPU]`     | Fixes lens flares and prevents geometry flickering |
| `vsync`           | `false`    | `[GPU]`     | Unlocks FPS (Combined with Framerate Limit set to 0) |
| `launch_module`   | `"scimitar_final.xex"` | `[General]` | Launches the singleplayer |

**Problems Fixed:**

- Lens flares and geometry flickering
- FPS capped to monitor refresh rate
- Launches multiplayer instead of singleplayer by default

### `555308C2` — Assassin's Creed IV Black Flag

| Setting           | Value      | Section     | Purpose                                      |
| ----------------- | ---------- | ----------- | -------------------------------------------- |
| `framerate_limit` | `120`      | `[GPU]`     | Caps the FPS to 60                           |
| `occlusion_query` | `"strict"` | `[GPU]`     | Prevents unoccluded lens flares              |
| `readback_resolve`| `"full"`   | `[GPU]`     | Fixes eye textures                           |
| `launch_module`   | `"scimitar_final.xex"` | `[General]` | Launches the singleplayer |

**Problems Fixed:**

- Uncapped framerate causing issues
- Unoccluded lens flares
- Broken eye textures
- Launches multiplayer instead of singleplayer by default

### `58410B3A` — I Am Alive

| Setting                 | Value  | Section | Purpose                          |
| ----------------------- | ------ | ------- | -------------------------------- |
| `clear_memory_page_state` | `true` | `[GPU]` | Fixes the flickering intro videos |
| `readback_resolve`      | `"fast"` | `[GPU]` | Fixes the brightness             |

**Problems Fixed:**

- Flickering intro videos
- Incorrect brightness levels

### `544307D5` — Ninja Gaiden 2

| Setting               | Value  | Section | Purpose                |
| --------------------- | ------ | ------- | ---------------------- |
| `apu_max_queued_frames` | (removed) | `[APU]` | Removed as now an emulator default |

**Problems Fixed:**

- Removed deprecated setting that is now handled by the emulator

---

## Screenshots

> Screenshots needed. Compare default vs. optimized settings for each game. Attach images directly or paste image URLs.

### `415607D4` — Tony Hawk's American Wasteland — `clear_memory_page_state` = `true`

|  Before (Default)   | After (Optimized)  |
| :-----------------: | :----------------: |
| ![Before](https://) | ![After](https://) |

_Flickering FMVs partially resolved by clearing memory page state._

### `45410866` — The Godfather II — `occlusion_query` = `fake`

|  Before (Default)   | After (Optimized)  |
| :-----------------: | :----------------: |
| ![Before](https://) | ![After](https://) |

_Geometry flickering eliminated with fake occlusion queries._

### `5345082A` — Aliens vs Predator — `render_target_path_d3d12` = `rov`

|  Before (Default)   | After (Optimized)  |
| :-----------------: | :----------------: |
| ![Before](https://) | ![After](https://) |

_Graphics now render correctly with ROV render target._

### `5451080D` — Red Faction Guerrilla — `vsync` = `false`

|  Before (Default)   | After (Optimized)  |
| :-----------------: | :----------------: |
| ![Before](https://) | ![After](https://) |

_FPS unlocked for smoother gameplay._

### `555307EA` — Brothers in Arms - Hell's Highway — `render_target_path_d3d12` = `rov`

|  Before (Default)   | After (Optimized)  |
| :-----------------: | :----------------: |
| ![Before](https://) | ![After](https://) |

_Shadow flickering fixed with ROV render target._

### `555308AE` — Assassin's Creed III — `occlusion_query` = `strict`

|  Before (Default)   | After (Optimized)  |
| :-----------------: | :----------------: |
| ![Before](https://) | ![After](https://) |

_Lens flares and geometry flickering resolved with strict occlusion queries._

### `555308C2` — Assassin's Creed IV Black Flag — `readback_resolve` = `full`

|  Before (Default)   | After (Optimized)  |
| :-----------------: | :----------------: |
| ![Before](https://) | ![After](https://) |

_Eye textures fixed with full readback resolve._

### `58410B3A` — I Am Alive — `clear_memory_page_state` = `true`

|  Before (Default)   | After (Optimized)  |
| :-----------------: | :----------------: |
| ![Before](https://) | ![After](https://) |

_Intro video flickering fixed and brightness corrected._

### `544307D5` — Ninja Gaiden 2 — `apu_max_queued_frames` removed

|  Before (Default)   | After (Optimized)  |
| :-----------------: | :----------------: |
| ![Before](https://) | ![After](https://) |

_Deprecated APU setting removed as it's now an emulator default._
Ninja Gaiden 2 (544307D5) had this removed setting