### PR TITLE
chore(settings): Update game-specific settings for 20 games

### DIFF
--- a/settings/415607E1.toml
+++ b/settings/415607E1.toml
@@ -3,3 +3,4 @@
 
 [GPU]
 framerate_limit = 120 # Caps the framerate to 120
+readback_resolve = "fast" # Fixes light corona occlusion

--- a/settings/454108CE.toml
+++ b/settings/454108CE.toml
@@ -4,3 +4,4 @@
 [GPU]
 occlusion_query = "strict" # Fixes unoccluded lens flares
 occlusion_query_saturation = 0.85 # Fixes unoccluded lens flares
+depth_bias_shader_offset = true # Fixes the decals

--- a/settings/4541095D.toml
+++ b/settings/4541095D.toml
@@ -3,3 +3,4 @@
 
 [GPU]
 occlusion_query = "strict" # Fixes unoccluded lens flares
+depth_bias_shader_offset = true # Fixes the decals

--- a/settings/494707EE.toml
+++ b/settings/494707EE.toml
@@ -3,3 +3,5 @@
 
 [GPU]
 occlusion_query = "fast-alt" # Fixes autoexposure issue (brightness)
+readback_resolve = "fast" # Works in concert with occlusion queries to fix auto-exposure
+force_depth_clamp = true # Fixes broken lighting in Escape From Butcher Bay Remake

--- a/settings/4D5307D3.toml
+++ b/settings/4D5307D3.toml
@@ -3,3 +3,4 @@
 
 [GPU]
 framerate_limit = 120 # Caps the FPS to 60
+depth_bias_shader_offset = true # Fixes the decals

--- a/settings/4D5307D5.toml
+++ b/settings/4D5307D5.toml
@@ -2,4 +2,5 @@
 # Title ID: 4D5307D5
 
 [GPU]
+depth_bias_shader_offset = true # Fixes the decals
 vsync = false # Unlocks framerate (Combined with framerate limit set to 0)

--- a/settings/4D5307E6.toml
+++ b/settings/4D5307E6.toml
@@ -3,6 +3,7 @@
 
 [GPU]
 readback_resolve = "full" # Fixes gamma
+depth_bias_shader_offset = true # Fixes the rare Z-fighting decal
 
 [Memory]
 protect_zero = false # Can fix some crashes

--- a/settings/4D5307E8.toml
+++ b/settings/4D5307E8.toml
@@ -4,3 +4,4 @@
 [GPU]
 occlusion_query = "strict" # Fixes unoccluded lens flares
 occlusion_query_saturation = 0.75 # Fixes excessively bright flares
+depth_bias_shader_offset = true # Fixes the decals

--- a/settings/4D5307FA.toml
+++ b/settings/4D5307FA.toml
@@ -2,7 +2,8 @@
 # Title ID: 4D5307FA
 
 [GPU]
-render_target_path_d3d12 = "rov" # Fixes broken character models
+depth_bias_shader_offset = true # Fixes broken character models
+draw_resolution_scale_threshold = 360 # Fixes post-process effects when using resolution scaling. Doesn't activate when rendering 1x1.
 
 [Storage]
 mount_scratch = true # Needed for getting ingame initially

--- a/settings/4D53082D.toml
+++ b/settings/4D53082D.toml
@@ -4,6 +4,7 @@
 [GPU]
 vsync = false # Unlocks framerate (Combined with framerate limit set to 0)
 occlusion_query = "strict" # Fixes unoccluded lens flares
+draw_resolution_scale_threshold = 360 # Fixes post-process effects when using resolution scaling. Doesn't activate when rendering 1x1.
 
 [Kernel]
 cl = "-NoStartupMovies" # Skips intro

--- a/settings/4D53085B.toml
+++ b/settings/4D53085B.toml
@@ -2,7 +2,7 @@
 # Title ID: 4D53085B
 
 [GPU]
-readback_resolve = "full" # Fixes the darker gamma at the cost of performance
+readback_resolve = "fast" # Fixes the darker gamma at the cost of performance
 
 [General]
 controller_hotkeys = true # Turn off Readback_Resolve with A + Guide Button after a few seconds

--- a/settings/4D530877.toml
+++ b/settings/4D530877.toml
@@ -2,4 +2,5 @@
 # Title ID: 4D530877
 
 [GPU]
-readback_resolve = "full" # Fixes excessive brightness
+readback_resolve = "fast" # Fixes excessive brightness
+depth_bias_shader_offset = true # Fixes the decals

--- a/settings/4D5308AB.toml
+++ b/settings/4D5308AB.toml
@@ -4,6 +4,7 @@
 [GPU]
 vsync = false # Unlocks framerate (Combined with framerate limit set to 0)
 occlusion_query = "strict" # Fixes unoccluded lens flares
+draw_resolution_scale_threshold = 360 # Fixes post-process effects when using resolution scaling. Doesn't activate when rendering 1x1.
 
 [Kernel]
 cl = "-NoStartupMovies" # Skips intro

--- a/settings/4D530919.toml
+++ b/settings/4D530919.toml
@@ -2,4 +2,4 @@
 # Title ID: 4D530919
 
 [GPU]
-readback_resolve = "full" # Fixes the darker gamma at the cost of performance
+readback_resolve = "fast" # Fixes the darker gamma at the cost of performance

--- a/settings/4D530A26.toml
+++ b/settings/4D530A26.toml
@@ -4,3 +4,4 @@
 [GPU]
 vsync = false # Unlocks framerate (Combined with framerate limit set to 0)
 occlusion_query = "strict" # Fixes unoccluded lens flares
+draw_resolution_scale_threshold = 360 # Fixes post-process effects when using resolution scaling. Doesn't activate when rendering 1x1.

--- a/settings/545107D1.toml
+++ b/settings/545107D1.toml
@@ -4,5 +4,8 @@
 [D3D12]
 d3d12_submit_on_primary_buffer_end = false # Fixes the blocky shadows if you ever get them
 
+[GPU]
+occlusion_query = "fast-alt" # Improves lens flare occlusion
+
 [Memory]
 protect_zero = false # Stops the game from crashing

--- a/settings/5451080D.toml
+++ b/settings/5451080D.toml
@@ -3,3 +3,4 @@
 
 [GPU]
 vsync = false # Unlocks FPS (Combined with Framerate Limit set to 0).
+occlusion_query = "strict" # Fixes unoccluded lens flares

--- a/settings/5451083B.toml
+++ b/settings/5451083B.toml
@@ -2,4 +2,4 @@
 # Title ID: 5451083B
 
 [GPU]
-render_target_path_d3d12 = "rov" # Fixes the decals
+depth_bias_shader_offset = true # Fixes the decals

--- a/settings/565707D0.toml
+++ b/settings/565707D0.toml
@@ -3,3 +3,5 @@
 
 [GPU]
 occlusion_query = "strict" # Fixes unoccluded lens flares
+depth_bias_shader_offset = true # Fixes the decals
+draw_resolution_scale_threshold = 256 # Fixes post-process effects when using resolution scaling. Doesn't activate when rendering 1x1.

--- a/settings/5841095A.toml
+++ b/settings/5841095A.toml
@@ -2,4 +2,5 @@
 # Title ID: 5841095A
 
 [GPU]
-readback_resolve = "full" # Fixes brightness at the cost of performance
+readback_resolve = "fast" # Fixes brightness at the cost of performance
+draw_resolution_scale_threshold = 512 # Reduces gaussian blur based upscaling artifacts. Stays inert when playing with 1x1 scaling.


### PR DESCRIPTION
## Summary

**Game(s):**

- `[415607E1]` — Call of Duty 3
- `[454108CE]` — Mass Effect 2
- `[4541095D]` — Mass Effect 3
- `[494707EE]` — Assault on Dark Athena
- `[4D5307D3]` — Perfect Dark Zero
- `[4D5307D5]` — Gears of War
- `[4D5307E6]` — Halo 3
- `[4D5307E8]` — Mass Effect
- `[4D5307FA]` — Lost Odyssey
- `[4D53082D]` — Gears of War 2
- `[4D53085B]` — Halo Reach
- `[4D530877]` — Halo 3 ODST
- `[4D5308AB]` — Gears of War 3
- `[4D530919]` — Halo 4
- `[4D530A26]` — Gears of War - Judgement
- `[545107D1]` — Saints Row
- `[5451080D]` — Red Faction Guerrilla
- `[5451083B]` — 50 Cent - Blood on the Sand
- `[565707D0]` — Lollipop Chainsaw
- `[5841095A]` — Trials HD

**Type:** `New Addition` / `Improvement`

Introducing `depth_bias_decal_clamp` for Z-fighting mitigation without needing to use shader interlock - mostly relevant for UE3 and Halo engine titles.

Some ZPD mode corrections.

Many of the titles that currently suggest full readback work just fine with fast readback instead.
